### PR TITLE
Allow lines to be split by either \n or \r\n, not just \n

### DIFF
--- a/rust_reject/src/main.rs
+++ b/rust_reject/src/main.rs
@@ -208,7 +208,7 @@ fn setup_graph(
         Err(_why) => panic!("couldn't read graphfile"),
         Ok(_) => (),
     }
-    let lines = s.split("\n");
+    let lines = s.lines();
     let mut label: State;
     let mut counter: usize = 0;
     let mut degree: usize;


### PR DESCRIPTION
Otherwise, an \r is left in the line strings, later leading to a ParseIntError (InvalidDigit).